### PR TITLE
Fix reading files from stdin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ fsel: fsel.c
 
 install: fsel
 	install -d $(DESTDIR)$(PREFIX)/bin
+	install -d $(DESTDIR)$(PREFIX)/share/man/man1
 	install -m 0755 fsel $(DESTDIR)$(PREFIX)/bin
 	install -m 0644 fsel.1 $(DESTDIR)$(PREFIX)/share/man/man1
 

--- a/fsel.c
+++ b/fsel.c
@@ -526,7 +526,8 @@ int main(int argc, char** argv) {
         return clear_mode(0, NULL, flags);
     }
 
-    if (optind >= argc) {
+    int has_input = !isatty(fileno(stdin));
+    if (optind >= argc && !has_input) {
         // When no paths are provided, default to list mode
         return list_mode(0, NULL, flags);
     }


### PR DESCRIPTION
I've tried the example commands from README, but to no success.
Turned out, that `ls -1 | fsel` would ignore stdin completely, because the program selects the "listing mode"