### PR TITLE
Fix build for other modern unix systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -Wall -Wextra -std=c11 -D_XOPEN_SOURCE=500
+CFLAGS = -Wall -Wextra -std=c11
 LDFLAGS =
 LIBS = -lcrypto
 PREFIX ?= /usr/local
@@ -12,6 +12,7 @@ fsel: fsel.c
 install: fsel
 	install -d $(DESTDIR)$(PREFIX)/bin
 	install -m 0755 fsel $(DESTDIR)$(PREFIX)/bin
+	install -d $(DESTDIR)$(PREFIX)/share/man/man1
 	install -m 0644 fsel.1 $(DESTDIR)$(PREFIX)/share/man/man1
 
 uninstall:


### PR DESCRIPTION
Removed XOPEN_SOURCE=500 because it is too old and restrictive. _DEFAULT_SOURCE should be used by default. That will be a good mix of standard POSIX functions and common GNU extensions without being as "all-inclusive" as _GNU_SOURCE.

Directory creation for man page was fixed in #2.

Change fixes #3 reported by @0-wiz-0.